### PR TITLE
#160213606 Eliminate null from numberofanswers attribute in get a question response object

### DIFF
--- a/server/controllers/QuestionController.js
+++ b/server/controllers/QuestionController.js
@@ -1,6 +1,6 @@
 import dbConnect from '../connections/dbConnect';
 import SqlHelper from '../helper/SqlHelper';
-import { formatQuestions, formatMostAnsweredQuestions } from '../helper/format';
+import { formatQuestions, formatMostAnsweredQuestions, formatQuestionsWithAnswers } from '../helper/format';
 import CatchErrors from '../helper/CatchErrors';
 
 const { catchDatabaseConnectionError } = CatchErrors;
@@ -146,7 +146,7 @@ class QuestionController {
             break;
 
           default: {
-            const reformedQuestion = formatQuestions(data.rows)[0];
+            const reformedQuestion = formatQuestionsWithAnswers(data.rows)[0];
             reformedQuestion.answers = request.foundAnswers;
             response.status(200).json({
               status: 'success',

--- a/server/helper/format.js
+++ b/server/helper/format.js
@@ -1,3 +1,18 @@
+const formatQuestionsWithAnswers = (data) => {
+  const newQuestions = [];
+  data.forEach((x) => {
+    newQuestions.push({
+      id: x.id,
+      questionTitle: x.questiontitle,
+      questionDescription: x.questiondescription,
+      answers: [],
+      time: x.time,
+      date: x.date,
+      userId: x.userid
+    });
+  });
+  return newQuestions;
+};
 
 const formatQuestions = (data) => {
   const newQuestions = [];
@@ -71,5 +86,5 @@ const formatComments = (data) => {
 };
 
 export {
-  formatQuestions, formatAnswers, formatComments, formatMostAnsweredQuestions
+  formatQuestions, formatAnswers, formatComments, formatMostAnsweredQuestions, formatQuestionsWithAnswers
 };


### PR DESCRIPTION
#### What does this PR do?
- This PR fixes a bug found when fetching a question. The number-of-answers attribute in question response object  returns null and therefore it is eliminated
#### Description of Task to be completed?
- Refine format method
#### How should this be manually tested?
- `npm test`
#### Any background context you want to provide?
-  None
#### What are the relevant pivotal tracker stories?
- #160213606
#### Screenshots (if appropriate)
- None
#### Questions:
- None
